### PR TITLE
Merging develop with main for a stable release of v1.0.0

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -31,4 +31,7 @@ jobs:
                   version: "~> v1"
                   args: release --clean
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,6 +58,8 @@ brews:
           email: bot@goreleaser.com # not sure if this will work yet
 
       repository:
+          token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+
           owner: kanennn
           name: homebrew-slate-tap 
 


### PR DESCRIPTION
I have updated the workflows again. They should now build to homebrew (by committing to remote tap) effectively.